### PR TITLE
Fix single quotes to backticks in string.ex

### DIFF
--- a/lib/elixir/lib/string.ex
+++ b/lib/elixir/lib/string.ex
@@ -645,7 +645,7 @@ defmodule String do
   end
 
   @doc ~S"""
-  Returns `true` if `string1` is canonically equivalent to 'string2'.
+  Returns `true` if `string1` is canonically equivalent to `string2`.
 
   It performs Normalization Form Canonical Decomposition (NFD) on the
   strings before comparing them. This function is equivalent to:


### PR DESCRIPTION
A variable name `string2` in the docs for `String.equivalent?/2` were enclosed in single quotes instead of backticks, fix it.